### PR TITLE
Editing filebeat-daemonset.yaml to reduce the amount of spam logs fil…

### DIFF
--- a/k8s/filebeat-daemonset.yaml
+++ b/k8s/filebeat-daemonset.yaml
@@ -45,10 +45,13 @@ metadata:
 data:
   filebeat.yml: |-
     filebeat.inputs:
-    - type: filestream
-      enabled: true
-      paths:
-        - /home/VMadmin/FYP_microservices/PEAR_patient_service/logs/*.log
+      - type: filestream
+        enabled: true
+        paths:
+          - /home/VMadmin/FYP_microservices/PEAR_patient_service/logs/*.log
+        ignore_older: 24h 
 
+    logging.level: warning
+    
     output.logstash:    
       hosts: ["192.168.188.184:5044"]


### PR DESCRIPTION
Currently, filebeat is generating logs every 10 seconds for INFO & WARNING for old files which are redundant. The configuration has been modified to reduce this logs to prevent hogging of storage space.