### PR TITLE
test: add unit tests for CRUD modules

### DIFF
--- a/app/crud/patient_list_crud.py
+++ b/app/crud/patient_list_crud.py
@@ -9,7 +9,7 @@ def get_all_list_types(db: Session):
     return db.query(PatientList).all()
 
 def get_list(db: Session, list_type: str, item_id: int = None):
-    query = db.query(PatientList).filter(PatientList.list_type == list_type)
+    query = db.query(PatientList).filter(PatientList.type == list_type)
     if item_id:
         query = query.filter(PatientList.id == item_id)
     return query.all()

--- a/tests/unit/test_patient.py
+++ b/tests/unit/test_patient.py
@@ -1,0 +1,196 @@
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.crud.patient_crud import (
+    create_patient,
+    delete_patient,
+    get_patient,
+    get_patients,
+    get_patients_by_doctor,
+    update_patient,
+)
+from app.schemas.patient import PatientCreate, PatientUpdate
+from tests.utils.mock_db import get_db_session_mock
+
+
+def test_get_patient_found(db_session_mock):
+    mock_patient = MagicMock(id=1, name="John Doe", nric="S1234567A", isDeleted=0)
+    mock_patient.mask_nric = "SXXXXX67A"
+    db_session_mock.query.return_value.options.return_value.filter.return_value.first.return_value = mock_patient
+
+    result = get_patient(db_session_mock, 1)
+
+    assert result is mock_patient
+    assert result.nric == "SXXXXX67A"
+
+
+def test_get_patient_not_found(db_session_mock):
+    db_session_mock.query.return_value.options.return_value.filter.return_value.first.return_value = None
+
+    result = get_patient(db_session_mock, 999)
+
+    assert result is None
+
+
+def test_get_patients_returns_list(db_session_mock):
+    mock_patient = MagicMock(id=1, name="John Doe", nric="S1234567A")
+    mock_patient.mask_nric = "SXXXXX67A"
+
+    mock_patient_query = MagicMock()
+    mock_patient_query.options.return_value.filter.return_value.order_by.return_value.offset.return_value.limit.return_value.all.return_value = [mock_patient]
+
+    mock_count_query = MagicMock()
+    mock_count_query.select_from.return_value.filter.return_value.scalar.return_value = 1
+
+    db_session_mock.query.side_effect = [mock_patient_query, mock_count_query]
+
+    patients, total_records, total_pages = get_patients(db_session_mock)
+
+    assert len(patients) == 1
+    assert total_records == 1
+    assert total_pages == 1
+
+
+def test_get_patients_by_doctor_returns_list(db_session_mock):
+    mock_patient = MagicMock(id=1, name="Jane Doe", nric="S7654321B")
+    mock_patient.mask_nric = "SXXXXX21B"
+
+    mock_filter = (
+        db_session_mock.query.return_value
+        .options.return_value
+        .join.return_value
+        .filter.return_value
+    )
+    mock_filter.count.return_value = 1
+    mock_filter.order_by.return_value.offset.return_value.limit.return_value.all.return_value = [mock_patient]
+
+    patients, total_records, total_pages = get_patients_by_doctor(db_session_mock, "doctor-1")
+
+    assert len(patients) == 1
+    assert total_records == 1
+    assert total_pages == 1
+
+
+@patch("app.crud.patient_crud.get_outbox_service")
+@patch("app.crud.patient_crud.log_crud_action")
+def test_create_patient(mock_log, mock_outbox_fn, db_session_mock, patient_create):
+    mock_new_patient = MagicMock(id=1, name=patient_create.name, nric=patient_create.nric)
+
+    mock_nric_check = MagicMock()
+    mock_nric_check.filter.return_value.first.return_value = None
+
+    mock_guardian_check = MagicMock()
+    mock_guardian_check.filter.return_value.first.return_value = None
+
+    mock_fetch = MagicMock()
+    mock_fetch.filter.return_value.first.return_value = mock_new_patient
+
+    db_session_mock.query.side_effect = [mock_nric_check, mock_guardian_check, mock_fetch]
+
+    result = create_patient(db_session_mock, patient_create, "user1", "User One")
+
+    db_session_mock.execute.assert_called_once()
+    db_session_mock.flush.assert_called_once()
+    db_session_mock.commit.assert_called_once()
+    assert result is mock_new_patient
+
+
+@patch("app.crud.patient_crud.get_outbox_service")
+@patch("app.crud.patient_crud.log_crud_action")
+def test_update_patient_found(mock_log, mock_outbox_fn, db_session_mock, patient_update):
+    mock_patient = MagicMock(id=1, nric="S1234567A", isDeleted=0, name="Old Name")
+
+    mock_fetch = MagicMock()
+    mock_fetch.filter.return_value.first.return_value = mock_patient
+
+    mock_nric_check = MagicMock()
+    mock_nric_check.filter.return_value.first.return_value = None
+
+    mock_guardian_check = MagicMock()
+    mock_guardian_check.filter.return_value.first.return_value = None
+
+    db_session_mock.query.side_effect = [mock_fetch, mock_nric_check, mock_guardian_check]
+
+    result = update_patient(db_session_mock, 1, patient_update, "user1", "User One")
+
+    assert result is mock_patient
+
+
+def test_update_patient_not_found(db_session_mock, patient_update):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+
+    with pytest.raises(HTTPException) as exc_info:
+        update_patient(db_session_mock, 999, patient_update, "user1", "User One")
+
+    assert exc_info.value.status_code == 404
+
+
+@patch("app.crud.patient_crud.get_outbox_service")
+@patch("app.crud.patient_crud.log_crud_action")
+def test_delete_patient_soft_delete(mock_log, mock_outbox_fn, db_session_mock):
+    mock_patient = MagicMock(id=1, name="John Doe", isDeleted=0)
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_patient
+
+    delete_patient(db_session_mock, 1, "user1", "User One")
+
+    assert mock_patient.isDeleted == "1"
+    db_session_mock.commit.assert_called_once()
+
+
+def test_delete_patient_not_found(db_session_mock):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+
+    with pytest.raises(HTTPException) as exc_info:
+        delete_patient(db_session_mock, 999, "user1", "User One")
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.fixture
+def db_session_mock():
+    return get_db_session_mock()
+
+
+@pytest.fixture
+def patient_create():
+    return PatientCreate(
+        name="John Doe",
+        nric="S1234567A",
+        gender="M",
+        dateOfBirth=datetime(1990, 1, 1),
+        isApproved="1",
+        preferredLanguageId=1,
+        updateBit="1",
+        autoGame="0",
+        startDate=datetime.now(),
+        isActive="1",
+        isRespiteCare="0",
+        privacyLevel=0,
+        createdDate=datetime.now(),
+        modifiedDate=datetime.now(),
+        CreatedById="1",
+        ModifiedById="1",
+    )
+
+
+@pytest.fixture
+def patient_update():
+    return PatientUpdate(
+        name="John Doe Updated",
+        nric="S1234567A",
+        gender="M",
+        dateOfBirth=datetime(1990, 1, 1),
+        isApproved="1",
+        preferredLanguageId=1,
+        updateBit="1",
+        autoGame="0",
+        startDate=datetime.now(),
+        isActive="1",
+        isRespiteCare="0",
+        privacyLevel=0,
+        modifiedDate=datetime.now(),
+        ModifiedById="1",
+    )

--- a/tests/unit/test_patient_allocation.py
+++ b/tests/unit/test_patient_allocation.py
@@ -1,0 +1,188 @@
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.crud.patient_allocation_crud import (
+    create_allocation,
+    delete_allocation,
+    get_all_allocations,
+    get_allocation_by_id,
+    get_allocation_by_patient,
+    get_guardian_id_by_patient,
+    update_allocation,
+)
+from app.schemas.patient_allocation import PatientAllocationCreate, PatientAllocationUpdate
+from tests.utils.mock_db import get_db_session_mock
+
+
+def test_get_allocation_by_id_found(db_session_mock):
+    mock_allocation = MagicMock(id=1, patientId=1, active="Y")
+    mock_guardian_user_id = "guardian-user-123"
+    db_session_mock.query.return_value.join.return_value.filter.return_value.first.return_value = (
+        mock_allocation, mock_guardian_user_id
+    )
+
+    result = get_allocation_by_id(db_session_mock, 1)
+
+    assert result is not None
+    assert result["guardianApplicationUserId"] == mock_guardian_user_id
+
+
+def test_get_allocation_by_id_not_found(db_session_mock):
+    db_session_mock.query.return_value.join.return_value.filter.return_value.first.return_value = None
+
+    result = get_allocation_by_id(db_session_mock, 999)
+
+    assert result is None
+
+
+def test_get_allocation_by_patient_found(db_session_mock):
+    mock_allocation = MagicMock(id=1, patientId=1, active="Y")
+    mock_guardian_user_id = "guardian-user-123"
+    db_session_mock.query.return_value.join.return_value.filter.return_value.first.return_value = (
+        mock_allocation, mock_guardian_user_id
+    )
+
+    result = get_allocation_by_patient(db_session_mock, 1)
+
+    assert result is not None
+    assert result["guardianApplicationUserId"] == mock_guardian_user_id
+
+
+def test_get_allocation_by_patient_not_found(db_session_mock):
+    db_session_mock.query.return_value.join.return_value.filter.return_value.first.return_value = None
+
+    result = get_allocation_by_patient(db_session_mock, 999)
+
+    assert result is None
+
+
+def test_get_guardian_id_by_patient_found(db_session_mock):
+    db_session_mock.query.return_value.join.return_value.filter.return_value.first.return_value = ("guardian-user-123",)
+
+    result = get_guardian_id_by_patient(db_session_mock, 1)
+
+    assert result == "guardian-user-123"
+
+
+def test_get_all_allocations_returns_list(db_session_mock):
+    mock_a = MagicMock(id=1, patientId=1, active="Y")
+    db_session_mock.query.return_value.join.return_value.filter.return_value.order_by.return_value.offset.return_value.limit.return_value.all.return_value = [
+        (mock_a, "guardian-user-123")
+    ]
+
+    result = get_all_allocations(db_session_mock)
+
+    assert result is not None
+    assert len(result) == 1
+    assert result[0]["guardianApplicationUserId"] == "guardian-user-123"
+
+
+def test_get_all_allocations_empty(db_session_mock):
+    db_session_mock.query.return_value.join.return_value.filter.return_value.order_by.return_value.offset.return_value.limit.return_value.all.return_value = []
+
+    result = get_all_allocations(db_session_mock)
+
+    assert result is None
+
+
+@patch("app.crud.patient_allocation_crud.get_allocation_by_patient", return_value=None)
+@patch("app.crud.patient_allocation_crud.get_outbox_service")
+@patch("app.crud.patient_allocation_crud.log_crud_action")
+def test_create_allocation_happy_path(mock_log, mock_outbox_fn, mock_get_alloc, db_session_mock, allocation_create):
+    result = create_allocation(db_session_mock, allocation_create, "user1", "User One")
+
+    db_session_mock.add.assert_called_once()
+    db_session_mock.flush.assert_called_once()
+    db_session_mock.commit.assert_called_once()
+    db_session_mock.refresh.assert_called_once()
+
+
+@patch("app.crud.patient_allocation_crud.get_allocation_by_patient", return_value={"id": 1, "patientId": 1})
+def test_create_allocation_duplicate_raises(mock_get_alloc, db_session_mock, allocation_create):
+    with pytest.raises(ValueError, match="Patient already has an active allocation"):
+        create_allocation(db_session_mock, allocation_create, "user1", "User One")
+
+
+@patch("app.crud.patient_allocation_crud.get_outbox_service")
+@patch("app.crud.patient_allocation_crud.log_crud_action")
+def test_update_allocation_found(mock_log, mock_outbox_fn, db_session_mock, allocation_update):
+    mock_allocation = MagicMock(id=1, patientId=1, active="Y", doctorId="old-doctor")
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_allocation
+
+    result = update_allocation(db_session_mock, 1, allocation_update, "user1", "User One")
+
+    db_session_mock.commit.assert_called_once()
+    assert result is mock_allocation
+
+
+def test_update_allocation_not_found(db_session_mock, allocation_update):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+
+    result = update_allocation(db_session_mock, 999, allocation_update, "user1", "User One")
+
+    assert result is None
+
+
+def test_update_allocation_inactive_raises(db_session_mock, allocation_update):
+    mock_allocation = MagicMock(id=1, patientId=1, active="N")
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_allocation
+
+    with pytest.raises(ValueError, match="Cannot update inactive allocation"):
+        update_allocation(db_session_mock, 1, allocation_update, "user1", "User One")
+
+
+@patch("app.crud.patient_allocation_crud.get_outbox_service")
+@patch("app.crud.patient_allocation_crud.log_crud_action")
+def test_delete_allocation_happy_path(mock_log, mock_outbox_fn, db_session_mock):
+    mock_allocation = MagicMock(id=1, patientId=1, active="Y")
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_allocation
+
+    result = delete_allocation(db_session_mock, 1, "user1", "User One")
+
+    assert mock_allocation.isDeleted == "1"
+    db_session_mock.commit.assert_called_once()
+    assert result is mock_allocation
+
+
+def test_delete_allocation_not_found(db_session_mock):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+
+    result = delete_allocation(db_session_mock, 999, "user1", "User One")
+
+    assert result is None
+
+
+def test_delete_allocation_already_inactive_raises(db_session_mock):
+    mock_allocation = MagicMock(id=1, patientId=1, active="N")
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_allocation
+
+    with pytest.raises(ValueError, match="Allocation is already inactive"):
+        delete_allocation(db_session_mock, 1, "user1", "User One")
+
+
+@pytest.fixture
+def db_session_mock():
+    return get_db_session_mock()
+
+
+@pytest.fixture
+def allocation_create():
+    return PatientAllocationCreate(
+        patientId=1,
+        guardianId=1,
+        doctorId="doctor-1",
+        CreatedById="1",
+        ModifiedById="1",
+    )
+
+
+@pytest.fixture
+def allocation_update():
+    return PatientAllocationUpdate(
+        patientId=1,
+        guardianId=1,
+        doctorId="doctor-2",
+        ModifiedById="1",
+    )

--- a/tests/unit/test_patient_guardian_relationship_mapping.py
+++ b/tests/unit/test_patient_guardian_relationship_mapping.py
@@ -1,0 +1,123 @@
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.crud.patient_guardian_relationship_mapping_crud import (
+    create_relationship_mapping,
+    delete_relationship_mapping,
+    get_relationship_mapping,
+    get_relationshipId_by_relationshipName,
+    update_relationship_mapping,
+)
+from app.schemas.patient_guardian_relationship_mapping import (
+    PatientGuardianRelationshipMappingCreate,
+    PatientGuardianRelationshipMappingUpdate,
+)
+from tests.utils.mock_db import get_db_session_mock
+
+
+def test_get_relationship_mapping_found(db_session_mock):
+    mock_mapping = MagicMock(id=1, relationshipName="Son", isDeleted="0")
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_mapping
+
+    result = get_relationship_mapping(db_session_mock, 1)
+
+    assert result is mock_mapping
+
+
+def test_get_relationship_mapping_not_found(db_session_mock):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+
+    result = get_relationship_mapping(db_session_mock, 999)
+
+    assert result is None
+
+
+def test_get_relationship_by_name_found(db_session_mock):
+    mock_mapping = MagicMock(id=1, relationshipName="Son", isDeleted="0")
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_mapping
+
+    result = get_relationshipId_by_relationshipName(db_session_mock, "Son")
+
+    assert result is mock_mapping
+    assert result.relationshipName == "Son"
+
+
+def test_get_relationship_by_name_not_found(db_session_mock):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+
+    result = get_relationshipId_by_relationshipName(db_session_mock, "Unknown")
+
+    assert result is None
+
+
+@patch("app.crud.patient_guardian_relationship_mapping_crud.log_crud_action")
+def test_create_relationship_mapping(mock_log, db_session_mock, relationship_create):
+    result = create_relationship_mapping(db_session_mock, relationship_create)
+
+    db_session_mock.add.assert_called_once_with(result)
+    db_session_mock.commit.assert_called_once()
+    db_session_mock.refresh.assert_called_once_with(result)
+    assert result.relationshipName == relationship_create.relationshipName
+
+
+@patch("app.crud.patient_guardian_relationship_mapping_crud.log_crud_action")
+def test_update_relationship_mapping_found(mock_log, db_session_mock, relationship_update):
+    mock_mapping = MagicMock(id=1, relationshipName="Son", isDeleted="0")
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_mapping
+
+    result = update_relationship_mapping(db_session_mock, 1, relationship_update)
+
+    db_session_mock.commit.assert_called_once()
+    db_session_mock.refresh.assert_called_once_with(mock_mapping)
+    assert result is mock_mapping
+
+
+def test_update_relationship_mapping_not_found(db_session_mock, relationship_update):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+
+    result = update_relationship_mapping(db_session_mock, 999, relationship_update)
+
+    assert result is None
+
+
+@patch("app.crud.patient_guardian_relationship_mapping_crud.log_crud_action")
+def test_delete_relationship_mapping_found(mock_log, db_session_mock):
+    mock_mapping = MagicMock(id=1, relationshipName="Son", isDeleted="0")
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_mapping
+
+    result = delete_relationship_mapping(db_session_mock, 1)
+
+    assert mock_mapping.isDeleted == "1"
+    db_session_mock.commit.assert_called_once()
+    assert result is mock_mapping
+
+
+def test_delete_relationship_mapping_not_found(db_session_mock):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+
+    result = delete_relationship_mapping(db_session_mock, 999)
+
+    assert result is None
+
+
+@pytest.fixture
+def db_session_mock():
+    return get_db_session_mock()
+
+
+@pytest.fixture
+def relationship_create():
+    return PatientGuardianRelationshipMappingCreate(
+        isDeleted="0",
+        relationshipName="Son",
+    )
+
+
+@pytest.fixture
+def relationship_update():
+    return PatientGuardianRelationshipMappingUpdate(
+        isDeleted="0",
+        relationshipName="Daughter",
+    )

--- a/tests/unit/test_patient_list.py
+++ b/tests/unit/test_patient_list.py
@@ -1,0 +1,125 @@
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.crud.patient_list_crud import (
+    create_list_item,
+    delete_list_item,
+    get_all_list_types,
+    get_list,
+    update_list_item,
+)
+from app.schemas.patient_list import PatientListCreate, PatientListUpdate
+from tests.utils.mock_db import get_db_session_mock
+
+
+def test_get_all_list_types(db_session_mock):
+    mock_data = [
+        MagicMock(id=1, type="diet", value="Vegetarian"),
+        MagicMock(id=2, type="diet", value="Vegan"),
+    ]
+    db_session_mock.query.return_value.all.return_value = mock_data
+
+    result = get_all_list_types(db_session_mock)
+
+    assert len(result) == 2
+    assert result[0].type == "diet"
+
+
+def test_get_list_by_type(db_session_mock):
+    mock_data = [MagicMock(id=1, type="diet", value="Vegetarian")]
+    db_session_mock.query.return_value.filter.return_value.all.return_value = mock_data
+
+    result = get_list(db_session_mock, "diet")
+
+    assert len(result) == 1
+    assert result[0].value == "Vegetarian"
+
+
+def test_get_list_by_type_and_id(db_session_mock):
+    mock_data = [MagicMock(id=1, type="diet", value="Vegetarian")]
+    db_session_mock.query.return_value.filter.return_value.filter.return_value.all.return_value = mock_data
+
+    result = get_list(db_session_mock, "diet", item_id=1)
+
+    assert len(result) == 1
+    assert result[0].id == 1
+
+
+@patch("app.crud.patient_list_crud.log_crud_action")
+def test_create_list_item(mock_log, db_session_mock, list_create):
+    result = create_list_item(db_session_mock, list_create)
+
+    db_session_mock.add.assert_called_once_with(result)
+    db_session_mock.commit.assert_called_once()
+    db_session_mock.refresh.assert_called_once_with(result)
+    assert result.type == list_create.type
+    assert result.value == list_create.value
+
+
+@patch("app.crud.patient_list_crud.log_crud_action")
+def test_update_list_item_found(mock_log, db_session_mock, list_update):
+    mock_item = MagicMock(id=1, type="diet", value="Vegetarian")
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_item
+
+    result = update_list_item(db_session_mock, 1, list_update)
+
+    db_session_mock.commit.assert_called_once()
+    db_session_mock.refresh.assert_called_once_with(mock_item)
+    assert result is mock_item
+
+
+def test_update_list_item_not_found(db_session_mock, list_update):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+
+    result = update_list_item(db_session_mock, 999, list_update)
+
+    assert result is None
+
+
+@patch("app.crud.patient_list_crud.log_crud_action")
+def test_delete_list_item_found(mock_log, db_session_mock):
+    mock_item = MagicMock(id=1, type="diet", value="Vegetarian")
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_item
+
+    result = delete_list_item(db_session_mock, 1)
+
+    db_session_mock.delete.assert_called_once_with(mock_item)
+    db_session_mock.commit.assert_called_once()
+    assert result is mock_item
+
+
+def test_delete_list_item_not_found(db_session_mock):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+
+    result = delete_list_item(db_session_mock, 999)
+
+    assert result is None
+
+
+@pytest.fixture
+def db_session_mock():
+    return get_db_session_mock()
+
+
+@pytest.fixture
+def list_create():
+    return PatientListCreate(
+        type="diet",
+        value="Vegetarian",
+        createdDate=datetime.now(),
+        modifiedDate=datetime.now(),
+        CreatedById="1",
+        ModifiedById="1",
+    )
+
+
+@pytest.fixture
+def list_update():
+    return PatientListUpdate(
+        type="diet",
+        value="Vegan",
+        modifiedDate=datetime.now(),
+        ModifiedById="1",
+    )

--- a/tests/unit/test_patient_list_language.py
+++ b/tests/unit/test_patient_list_language.py
@@ -1,0 +1,148 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.crud.patient_list_language_crud import (
+    create_patient_list_language,
+    delete_patient_list_language,
+    get_all_patient_list_language,
+    get_patient_list_language,
+    update_patient_list_language,
+)
+from app.schemas.patient_list_language import (
+    PatientListLanguageCreate,
+    PatientListLanguageUpdate,
+)
+from tests.utils.mock_db import get_db_session_mock
+
+
+def test_get_language_found(db_session_mock):
+    mock_lang = MagicMock(id=1, value="English", isDeleted="0")
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_lang
+
+    result = get_patient_list_language(db_session_mock, 1)
+
+    assert result is mock_lang
+
+
+def test_get_language_not_found(db_session_mock):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+
+    with pytest.raises(HTTPException) as exc_info:
+        get_patient_list_language(db_session_mock, 999)
+
+    assert exc_info.value.status_code == 404
+
+
+def test_get_all_languages(db_session_mock):
+    mock_data = [
+        MagicMock(id=1, value="English", isDeleted="0"),
+        MagicMock(id=2, value="Mandarin", isDeleted="0"),
+    ]
+    db_session_mock.query.return_value.filter.return_value.all.return_value = mock_data
+
+    result = get_all_patient_list_language(db_session_mock)
+
+    assert len(result) == 2
+
+
+def test_create_language_happy_path(db_session_mock, language_create):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+
+    result = create_patient_list_language(db_session_mock, language_create)
+
+    db_session_mock.add.assert_called_once_with(result)
+    db_session_mock.commit.assert_called_once()
+    db_session_mock.refresh.assert_called_once_with(result)
+
+
+def test_create_language_duplicate_raises_400(db_session_mock, language_create):
+    mock_existing = MagicMock(id=1, value="English", isDeleted="0")
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_existing
+
+    with pytest.raises(HTTPException) as exc_info:
+        create_patient_list_language(db_session_mock, language_create)
+
+    assert exc_info.value.status_code == 400
+
+
+def test_update_language_happy_path(db_session_mock, language_update):
+    mock_lang = MagicMock(id=1, value="English", isDeleted="0")
+
+    mock_find_query = MagicMock()
+    mock_find_query.filter.return_value.first.return_value = mock_lang
+
+    mock_dup_query = MagicMock()
+    mock_dup_query.filter.return_value.first.return_value = None
+
+    db_session_mock.query.side_effect = [mock_find_query, mock_dup_query]
+
+    result = update_patient_list_language(db_session_mock, 1, language_update)
+
+    db_session_mock.commit.assert_called_once()
+    db_session_mock.refresh.assert_called_once_with(mock_lang)
+    assert result is mock_lang
+
+
+def test_update_language_not_found_raises_404(db_session_mock, language_update):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+
+    with pytest.raises(HTTPException) as exc_info:
+        update_patient_list_language(db_session_mock, 999, language_update)
+
+    assert exc_info.value.status_code == 404
+
+
+def test_update_language_duplicate_raises_400(db_session_mock, language_update):
+    mock_lang = MagicMock(id=1, value="English", isDeleted="0")
+    mock_duplicate = MagicMock(id=2, value="Mandarin", isDeleted="0")
+
+    mock_find_query = MagicMock()
+    mock_find_query.filter.return_value.first.return_value = mock_lang
+
+    mock_dup_query = MagicMock()
+    mock_dup_query.filter.return_value.first.return_value = mock_duplicate
+
+    db_session_mock.query.side_effect = [mock_find_query, mock_dup_query]
+
+    with pytest.raises(HTTPException) as exc_info:
+        update_patient_list_language(db_session_mock, 1, language_update)
+
+    assert exc_info.value.status_code == 400
+
+
+def test_delete_language_happy_path(db_session_mock):
+    mock_lang = MagicMock(id=1, value="English", isDeleted="0")
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_lang
+
+    result = delete_patient_list_language(db_session_mock, 1)
+
+    assert mock_lang.isDeleted == "1"
+    db_session_mock.commit.assert_called_once()
+    assert result is mock_lang
+
+
+def test_delete_language_not_found_raises_404(db_session_mock):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+
+    with pytest.raises(HTTPException) as exc_info:
+        delete_patient_list_language(db_session_mock, 999)
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.fixture
+def db_session_mock():
+    return get_db_session_mock()
+
+
+@pytest.fixture
+def language_create():
+    return PatientListLanguageCreate(value="English")
+
+
+@pytest.fixture
+def language_update():
+    return PatientListLanguageUpdate(value="Mandarin")

--- a/tests/unit/test_patient_patient_guardian.py
+++ b/tests/unit/test_patient_patient_guardian.py
@@ -1,0 +1,193 @@
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.crud.patient_patient_guardian_crud import (
+    create_patient_patient_guardian,
+    delete_patient_patient_guardian_by_guardianId,
+    delete_relationship,
+    get_all_patient_guardian_by_patientId,
+    get_all_patient_patient_guardian_by_guardianId,
+    update_patient_patient_guardian,
+)
+from app.schemas.patient_patient_guardian import (
+    PatientPatientGuardianCreate,
+    PatientPatientGuardianUpdate,
+)
+from tests.utils.mock_db import get_db_session_mock
+
+
+def test_get_by_patient_id_with_relationships(db_session_mock):
+    mock_relationship = MagicMock()
+    mock_relationship.relationship.relationshipName = "Son"
+    mock_relationship.patient_guardian = MagicMock()
+    mock_relationship.patient = MagicMock()
+    mock_relationship.patient.nric = "S1234567A"
+
+    db_session_mock.query.return_value.join.return_value.join.return_value.join.return_value.filter.return_value.all.return_value = [
+        mock_relationship
+    ]
+
+    with patch("app.crud.patient_patient_guardian_crud.PatientModel") as mock_patient_model, \
+         patch("app.crud.patient_patient_guardian_crud.PatientGuardianModel") as mock_guardian_model, \
+         patch("app.crud.patient_patient_guardian_crud.GuardianWithRelationshipModel") as mock_gwr:
+        mock_patient_model.from_orm.return_value = MagicMock()
+        mock_guardian_model.from_orm.return_value = MagicMock()
+        mock_gwr.return_value = MagicMock()
+
+        result = get_all_patient_guardian_by_patientId(db_session_mock, 1)
+
+    assert result is not None
+
+
+def test_get_by_patient_id_no_relationships_patient_exists(db_session_mock):
+    mock_patient_raw = MagicMock(id=1)
+
+    mock_rel_query = MagicMock()
+    mock_rel_query.join.return_value.join.return_value.join.return_value.filter.return_value.all.return_value = []
+
+    mock_patient_query = MagicMock()
+    mock_patient_query.filter.return_value.first.return_value = mock_patient_raw
+
+    db_session_mock.query.side_effect = [mock_rel_query, mock_patient_query]
+
+    with patch("app.crud.patient_patient_guardian_crud.PatientModel") as mock_model:
+        mock_model.from_orm.return_value = MagicMock()
+        result = get_all_patient_guardian_by_patientId(db_session_mock, 1)
+
+    assert result["patient_guardians"] == []
+
+
+def test_get_by_patient_id_no_relationships_no_patient(db_session_mock):
+    mock_rel_query = MagicMock()
+    mock_rel_query.join.return_value.join.return_value.join.return_value.filter.return_value.all.return_value = []
+
+    mock_patient_query = MagicMock()
+    mock_patient_query.filter.return_value.first.return_value = None
+
+    db_session_mock.query.side_effect = [mock_rel_query, mock_patient_query]
+
+    result = get_all_patient_guardian_by_patientId(db_session_mock, 999)
+
+    assert result is None
+
+
+def test_get_by_guardian_id_returns_list(db_session_mock):
+    mock_relationship = MagicMock()
+    mock_relationship.relationship.relationshipName = "Son"
+    mock_relationship.patient_guardian = MagicMock()
+    mock_relationship.patient = MagicMock()
+
+    db_session_mock.query.return_value.join.return_value.join.return_value.join.return_value.filter.return_value.all.return_value = [
+        mock_relationship
+    ]
+
+    with patch("app.crud.patient_patient_guardian_crud.PatientModel") as mock_patient_model, \
+         patch("app.crud.patient_patient_guardian_crud.PatientGuardianModel") as mock_guardian_model, \
+         patch("app.crud.patient_patient_guardian_crud.PatientWithRelationshipModel") as mock_pwr:
+        mock_patient_model.from_orm.return_value = MagicMock()
+        mock_guardian_model.from_orm.return_value = MagicMock()
+        mock_pwr.return_value = MagicMock()
+
+        result = get_all_patient_patient_guardian_by_guardianId(db_session_mock, "guardian-user-id")
+
+    assert result is not None
+
+
+@patch("app.crud.patient_patient_guardian_crud.log_crud_action")
+def test_create_patient_patient_guardian(mock_log, db_session_mock, ppg_create):
+    result = create_patient_patient_guardian(db_session_mock, ppg_create)
+
+    db_session_mock.add.assert_called_once_with(result)
+    db_session_mock.commit.assert_called_once()
+    db_session_mock.refresh.assert_called_once_with(result)
+
+
+@patch("app.crud.patient_patient_guardian_crud.log_crud_action")
+def test_update_patient_patient_guardian_found(mock_log, db_session_mock, ppg_update):
+    mock_rel = MagicMock(id=1, patientId=1, guardianId=1, isDeleted="0")
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_rel
+
+    result = update_patient_patient_guardian(db_session_mock, 1, ppg_update)
+
+    db_session_mock.commit.assert_called_once()
+    db_session_mock.refresh.assert_called_once_with(mock_rel)
+    assert result is mock_rel
+
+
+def test_update_patient_patient_guardian_not_found(db_session_mock, ppg_update):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+
+    result = update_patient_patient_guardian(db_session_mock, 999, ppg_update)
+
+    assert result is None
+
+
+@patch("app.crud.patient_patient_guardian_crud.log_crud_action")
+def test_delete_by_guardian_id_found(mock_log, db_session_mock):
+    mock_rel = MagicMock(id=1, guardianId=1, isDeleted="0")
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_rel
+
+    result = delete_patient_patient_guardian_by_guardianId(db_session_mock, 1)
+
+    assert mock_rel.isDeleted == "1"
+    db_session_mock.commit.assert_called_once()
+    assert result is mock_rel
+
+
+def test_delete_by_guardian_id_not_found(db_session_mock):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+
+    result = delete_patient_patient_guardian_by_guardianId(db_session_mock, 999)
+
+    assert result is None
+
+
+@patch("app.crud.patient_patient_guardian_crud.log_crud_action")
+def test_delete_relationship_found(mock_log, db_session_mock):
+    mock_rel = MagicMock(id=1, isDeleted="0")
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_rel
+
+    result = delete_relationship(db_session_mock, 1)
+
+    assert mock_rel.isDeleted == "1"
+    db_session_mock.commit.assert_called_once()
+    assert result is mock_rel
+
+
+def test_delete_relationship_not_found(db_session_mock):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+
+    result = delete_relationship(db_session_mock, 999)
+
+    assert result is None
+
+
+@pytest.fixture
+def db_session_mock():
+    return get_db_session_mock()
+
+
+@pytest.fixture
+def ppg_create():
+    return PatientPatientGuardianCreate(
+        isDeleted="0",
+        patientId=1,
+        guardianId=1,
+        relationshipId=1,
+        CreatedById="1",
+        ModifiedById="1",
+    )
+
+
+@pytest.fixture
+def ppg_update():
+    return PatientPatientGuardianUpdate(
+        isDeleted="0",
+        patientId=1,
+        guardianId=1,
+        relationshipId=2,
+        CreatedById="1",
+        ModifiedById="1",
+    )

--- a/tests/unit/test_patient_photo.py
+++ b/tests/unit/test_patient_photo.py
@@ -1,0 +1,199 @@
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.crud.patient_photo_crud import (
+    create_patient_photo,
+    delete_patient_photo,
+    delete_patient_photo_by_photo_id,
+    extract_public_id_from_url,
+    get_patient_photo_by_patient_id,
+    get_patient_photo_by_photo_id,
+    get_patient_photos,
+    update_patient_photo,
+    update_patient_photo_by_photo_id,
+)
+from app.schemas.patient_photo import PatientPhotoCreate, PatientPhotoUpdate
+from tests.utils.mock_db import get_db_session_mock
+
+
+def test_extract_public_id_with_version():
+    url = "https://res.cloudinary.com/demo/image/upload/v1234567/patients/photo.jpg"
+    result = extract_public_id_from_url(url)
+    assert result == "patients/photo"
+
+
+def test_extract_public_id_without_version():
+    url = "https://res.cloudinary.com/demo/image/upload/patients/photo.jpg"
+    result = extract_public_id_from_url(url)
+    assert result == "patients/photo"
+
+
+def test_extract_public_id_invalid_url():
+    result = extract_public_id_from_url("not-a-valid-url")
+    assert result is None
+
+
+def test_get_patient_photos(db_session_mock):
+    mock_data = [
+        MagicMock(PatientPhotoID=1, PatientID=1, IsDeleted=0),
+        MagicMock(PatientPhotoID=2, PatientID=2, IsDeleted=0),
+    ]
+    db_session_mock.query.return_value.filter.return_value.all.return_value = mock_data
+
+    result = get_patient_photos(db_session_mock)
+
+    assert len(result) == 2
+
+
+def test_get_patient_photo_by_patient_id_found(db_session_mock):
+    mock_data = [MagicMock(PatientPhotoID=1, PatientID=1, IsDeleted=0)]
+    db_session_mock.query.return_value.filter.return_value.all.return_value = mock_data
+
+    result = get_patient_photo_by_patient_id(db_session_mock, 1)
+
+    assert len(result) == 1
+    assert result[0].PatientID == 1
+
+
+def test_get_patient_photo_by_patient_id_not_found(db_session_mock):
+    db_session_mock.query.return_value.filter.return_value.all.return_value = []
+
+    result = get_patient_photo_by_patient_id(db_session_mock, 999)
+
+    assert result == []
+
+
+def test_get_patient_photo_by_photo_id_found(db_session_mock):
+    mock_photo = MagicMock(PatientPhotoID=1, PatientID=1, IsDeleted=0)
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_photo
+
+    result = get_patient_photo_by_photo_id(db_session_mock, 1)
+
+    assert result is mock_photo
+
+
+def test_get_patient_photo_by_photo_id_not_found(db_session_mock):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+
+    result = get_patient_photo_by_photo_id(db_session_mock, 999)
+
+    assert result is None
+
+
+@patch("app.crud.patient_photo_crud.upload_photo_to_cloudinary", return_value="https://cloudinary.com/photo.jpg")
+def test_create_patient_photo(mock_upload, db_session_mock, photo_create):
+    mock_file = MagicMock()
+
+    result = create_patient_photo(db_session_mock, mock_file, photo_create, "user1", "User One")
+
+    mock_upload.assert_called_once_with(mock_file)
+    assert result.PhotoPath == "https://cloudinary.com/photo.jpg"
+    db_session_mock.add.assert_called_once_with(result)
+    db_session_mock.commit.assert_called_once()
+    db_session_mock.refresh.assert_called_once_with(result)
+
+
+@patch("app.crud.patient_photo_crud.upload_photo_to_cloudinary", return_value="https://cloudinary.com/new.jpg")
+@patch("app.crud.patient_photo_crud.delete_photo_from_cloudinary", return_value=True)
+def test_update_patient_photo_found(mock_delete, mock_upload, db_session_mock, photo_update):
+    mock_photo = MagicMock(PatientID=1, PhotoPath="https://cloudinary.com/old.jpg", IsDeleted=0)
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_photo
+    mock_file = MagicMock()
+
+    result = update_patient_photo(db_session_mock, 1, mock_file, photo_update, "user1", "User One")
+
+    mock_delete.assert_called_once_with("https://cloudinary.com/old.jpg")
+    mock_upload.assert_called_once_with(mock_file)
+    assert mock_photo.PhotoPath == "https://cloudinary.com/new.jpg"
+    db_session_mock.commit.assert_called_once()
+    assert result is mock_photo
+
+
+def test_update_patient_photo_not_found(db_session_mock, photo_update):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+    mock_file = MagicMock()
+
+    result = update_patient_photo(db_session_mock, 999, mock_file, photo_update, "user1", "User One")
+
+    assert result is None
+
+
+@patch("app.crud.patient_photo_crud.delete_photo_from_cloudinary", return_value=True)
+def test_delete_patient_photo_found(mock_delete, db_session_mock):
+    mock_photos = [
+        MagicMock(PatientPhotoID=1, PatientID=1, PhotoPath="https://cloudinary.com/photo.jpg", IsDeleted=0),
+    ]
+    db_session_mock.query.return_value.filter.return_value.all.return_value = mock_photos
+
+    result = delete_patient_photo(db_session_mock, 1, "user1", "User One")
+
+    assert mock_photos[0].IsDeleted == 1
+    db_session_mock.commit.assert_called_once()
+    assert result is mock_photos
+
+
+def test_delete_patient_photo_not_found(db_session_mock):
+    db_session_mock.query.return_value.filter.return_value.all.return_value = []
+
+    result = delete_patient_photo(db_session_mock, 999, "user1", "User One")
+
+    assert result is None
+
+
+@patch("app.crud.patient_photo_crud.delete_photo_from_cloudinary", return_value=True)
+def test_delete_patient_photo_by_photo_id_found(mock_delete, db_session_mock):
+    mock_photo = MagicMock(PatientPhotoID=1, PhotoPath="https://cloudinary.com/photo.jpg", IsDeleted=0)
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_photo
+
+    result = delete_patient_photo_by_photo_id(db_session_mock, 1, "user1", "User One")
+
+    assert mock_photo.IsDeleted == 1
+    db_session_mock.commit.assert_called_once()
+    assert result is mock_photo
+
+
+def test_delete_patient_photo_by_photo_id_not_found(db_session_mock):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+
+    result = delete_patient_photo_by_photo_id(db_session_mock, 999, "user1", "User One")
+
+    assert result is None
+
+
+@patch("app.crud.patient_photo_crud.upload_photo_to_cloudinary", return_value="https://cloudinary.com/updated.jpg")
+@patch("app.crud.patient_photo_crud.delete_photo_from_cloudinary", return_value=True)
+def test_update_patient_photo_by_photo_id_found(mock_delete, mock_upload, db_session_mock, photo_update):
+    mock_photo = MagicMock(PatientPhotoID=1, PhotoPath="https://cloudinary.com/old.jpg", IsDeleted=0)
+    db_session_mock.query.return_value.filter.return_value.first.return_value = mock_photo
+    mock_file = MagicMock()
+
+    result = update_patient_photo_by_photo_id(db_session_mock, 1, mock_file, photo_update, "user1", "User One")
+
+    db_session_mock.commit.assert_called_once()
+    assert result is mock_photo
+
+
+def test_update_patient_photo_by_photo_id_not_found(db_session_mock, photo_update):
+    db_session_mock.query.return_value.filter.return_value.first.return_value = None
+    mock_file = MagicMock()
+
+    result = update_patient_photo_by_photo_id(db_session_mock, 999, mock_file, photo_update, "user1", "User One")
+
+    assert result is None
+
+
+@pytest.fixture
+def db_session_mock():
+    return get_db_session_mock()
+
+
+@pytest.fixture
+def photo_create():
+    return PatientPhotoCreate(PatientID=1, AlbumCategoryListID=1)
+
+
+@pytest.fixture
+def photo_update():
+    return PatientPhotoUpdate(PhotoDetails="Updated details")


### PR DESCRIPTION
**DO NOT MERGE BEFORE 11 MAY**

## Summary

- Add unit tests for 7 previously uncovered CRUD modules: `patient`, `patient_allocation`, `patient_list`, `patient_list_language`, `patient_guardian_relationship_mapping`, `patient_photo`, and `patient_patient_guardian`
- Fix `patient_list_crud.get_list()` which filtered on `PatientList.list_type` — a column that does not exist on the model (actual column is `type`); this caused an `AttributeError` crash on any call to that endpoint

## What changed

**New test files (7):**
- `tests/unit/test_patient.py`
- `tests/unit/test_patient_allocation.py`
- `tests/unit/test_patient_list.py`
- `tests/unit/test_patient_list_language.py`
- `tests/unit/test_patient_guardian_relationship_mapping.py`
- `tests/unit/test_patient_photo.py`
- `tests/unit/test_patient_patient_guardian.py`

**Bug fix (1):**
- `app/crud/patient_list_crud.py`: `PatientList.list_type` → `PatientList.type`

## Notes

- Suite: 375 passed, 0 failed.
- The `patient_list_crud` fix is a one-character column name correction. The old code would crash 100% of the time at runtime on `GET /list/{list_type}` calls, trivial fix.