### PR TITLE
feat: atomic patient creation with care staff allocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ logs/*.log
 
 # IntelliJ
 .idea/
+
+# Git worktrees
+.worktrees/

--- a/app/crud/patient_crud.py
+++ b/app/crud/patient_crud.py
@@ -12,7 +12,8 @@ from app.models.patient_allocation_model import PatientAllocation
 
 from ..logger.logger_utils import ActionType, log_crud_action, serialize_data
 from ..models.patient_model import Patient
-from ..schemas.patient import PatientCreate, PatientUpdate
+from ..schemas.patient import PatientCreate, PatientCreateWithAllocation, PatientUpdate
+from ..services.user_service import get_least_loaded_staff
 from ..services.outbox_service import generate_correlation_id, get_outbox_service
 
 logger = logging.getLogger(__name__)
@@ -277,7 +278,7 @@ def _patient_to_dict(patient) -> Dict[str, Any]:
         logger.error(f"Error converting patient to dict: {str(e)}")
         return {}
 
-def create_patient(db: Session, patient: PatientCreate, user: str, user_full_name: str, correlation_id: str = None):
+def create_patient(db: Session, patient: PatientCreateWithAllocation, user: str, user_full_name: str, correlation_id: str = None, api_key: str = None, supervisor_id: str = None):
     """ Create a new patient with message queue publishing """
 
     # Check NRIC uniqueness
@@ -305,6 +306,28 @@ def create_patient(db: Session, patient: PatientCreate, user: str, user_full_nam
             status_code=400,
             detail="Patient NRIC conflicts with an existing active guardian record"
         )
+
+    # Validate guardianId exists (only when provided via PatientCreateWithAllocation)
+    guardian_id = getattr(patient, "guardianId", None)
+    if guardian_id is not None:
+        guardian = (
+            db.query(PatientGuardianModel)
+            .filter(PatientGuardianModel.id == guardian_id, PatientGuardianModel.isDeleted == "0")
+            .first()
+        )
+        if not guardian:
+            raise HTTPException(status_code=400, detail="Guardian not found")
+
+    # Validate doctor2Id != doctorId
+    doctor_id = getattr(patient, "doctorId", None)
+    doctor2_id = getattr(patient, "doctor2Id", None)
+    if doctor2_id and doctor_id and doctor2_id == doctor_id:
+        raise HTTPException(status_code=400, detail="doctor2Id must differ from doctorId")
+
+    # Validate supervisor2Id != supervisorId
+    supervisor2_id = getattr(patient, "supervisor2Id", None)
+    if supervisor2_id and supervisor_id and supervisor2_id == supervisor_id:
+        raise HTTPException(status_code=400, detail="supervisor2Id must differ from supervisorId")
 
     # Generate correlation ID if not provided
     if not correlation_id:
@@ -411,12 +434,42 @@ def create_patient(db: Session, patient: PatientCreate, user: str, user_full_nam
             log_type= "patient_info",
         )
 
-        # 6. Commit both patient and outbox event atomically
+        # 6. Resolve care staff IDs and create allocation (only when guardianId is provided)
+        if guardian_id is not None:
+            resolved_doctor_id = getattr(patient, "doctorId", None) or get_least_loaded_staff("DOCTOR", db, api_key)
+            resolved_game_therapist_id = getattr(patient, "gameTherapistId", None) or get_least_loaded_staff("GAME THERAPIST", db, api_key)
+            resolved_caregiver_id = getattr(patient, "caregiverId", None) or get_least_loaded_staff("CAREGIVER", db, api_key)
+
+        # 7. Create allocation atomically (only when guardianId is provided)
+        if guardian_id is not None:
+            db_allocation = PatientAllocation(
+                active="Y",
+                patientId=new_patient.id,
+                guardianId=guardian_id,
+                guardian2Id=None,
+                doctorId=resolved_doctor_id,
+                gameTherapistId=resolved_game_therapist_id,
+                supervisorId=supervisor_id,
+                caregiverId=resolved_caregiver_id,
+                doctor2Id=getattr(patient, "doctor2Id", None),
+                supervisor2Id=getattr(patient, "supervisor2Id", None),
+                createdDate=timestamp,
+                modifiedDate=timestamp,
+                CreatedById=user,
+                ModifiedById=user,
+            )
+            db.add(db_allocation)
+            db.flush()
+
+        # 8. Commit patient, outbox event, and allocation atomically
         db.commit()
-        
+
         logger.info(f"Created patient {new_patient.id} with outbox event {outbox_event.id} (correlation: {correlation_id})")
         return new_patient
 
+    except HTTPException:
+        db.rollback()
+        raise
     except Exception as e:
         db.rollback()
         logger.error(f"Failed to create patient: {str(e)}")

--- a/app/crud/patient_crud.py
+++ b/app/crud/patient_crud.py
@@ -440,6 +440,10 @@ def create_patient(db: Session, patient: PatientCreateWithAllocation, user: str,
             resolved_game_therapist_id = getattr(patient, "gameTherapistId", None) or get_least_loaded_staff("GAME THERAPIST", db, api_key)
             resolved_caregiver_id = getattr(patient, "caregiverId", None) or get_least_loaded_staff("CAREGIVER", db, api_key)
 
+            doctor2_id = getattr(patient, "doctor2Id", None)
+            if doctor2_id and doctor2_id == resolved_doctor_id:
+                raise HTTPException(status_code=400, detail="doctor2Id must differ from doctorId")
+
         # 7. Create allocation atomically (only when guardianId is provided)
         if guardian_id is not None:
             db_allocation = PatientAllocation(

--- a/app/models/patient_allocation_model.py
+++ b/app/models/patient_allocation_model.py
@@ -20,6 +20,8 @@ class PatientAllocation(Base):
     gameTherapistId = Column(String, nullable=True)
     supervisorId = Column(String, nullable=True)
     caregiverId = Column(String, nullable=True)
+    doctor2Id = Column(String, nullable=True)
+    supervisor2Id = Column(String, nullable=True)
     tempDoctorId = Column(String)
     tempCaregiverId = Column(String)
     

--- a/app/routers/patient_router.py
+++ b/app/routers/patient_router.py
@@ -1,12 +1,13 @@
+import os
 from typing import Optional
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile
 from sqlalchemy.orm import Session
 
-from ..auth.jwt_utils import extract_jwt_payload, get_full_name, get_user_id
+from ..auth.jwt_utils import extract_jwt_payload, get_full_name, get_role_name, get_user_id
 from ..crud import patient_crud as crud_patient
 from ..database import get_db
-from ..schemas.patient import Patient, PatientCreate, PatientUpdate
+from ..schemas.patient import Patient, PatientCreate, PatientCreateWithAllocation, PatientUpdate
 from ..schemas.response import PaginatedResponse, SingleResponse
 
 router = APIRouter()
@@ -173,13 +174,23 @@ def get_patients_by_guardian_application_user_id(
     )
 
 @router.post("/patients/add", response_model=SingleResponse[Patient])
-def create_patient(patient: PatientCreate, request: Request, require_auth: bool = True, db: Session = Depends(get_db)):
+def create_patient(patient: PatientCreateWithAllocation, request: Request, require_auth: bool = True, db: Session = Depends(get_db)):
     payload = extract_jwt_payload(request, require_auth)
     user_id = get_user_id(payload) or "1"
     user_full_name = get_full_name(payload) or "Anonymous User"
-    db_patient = crud_patient.create_patient(db, patient, user_id, user_full_name)
-    patient = Patient.model_validate(db_patient)
-    return SingleResponse(data=patient)
+    role_name = get_role_name(payload)
+
+    if role_name != "SUPERVISOR":
+        raise HTTPException(status_code=403, detail="Only supervisors can create patients")
+
+    api_key = os.environ.get("INTERNAL_SERVICE_API_KEY")
+
+    db_patient = crud_patient.create_patient(
+        db, patient, user_id, user_full_name,
+        api_key=api_key, supervisor_id=user_id
+    )
+    patient_out = Patient.model_validate(db_patient)
+    return SingleResponse(data=patient_out)
 
 @router.put("/patients/update/{patient_id}", response_model=SingleResponse[Patient])
 def update_patient(patient_id: int, patient: PatientUpdate, request: Request, require_auth: bool = True, db: Session = Depends(get_db)):

--- a/app/schemas/patient.py
+++ b/app/schemas/patient.py
@@ -49,3 +49,8 @@ class Patient(PatientBase):
     ModifiedById: str = Field(json_schema_extra={"example": "1"})
     preferred_language: Optional[str] = None
     model_config = {"from_attributes": True}
+
+class PatientCreateWithAllocation(PatientCreate):
+    guardianId: int
+    doctor2Id: Optional[str] = None
+    supervisor2Id: Optional[str] = None

--- a/app/schemas/patient.py
+++ b/app/schemas/patient.py
@@ -52,5 +52,8 @@ class Patient(PatientBase):
 
 class PatientCreateWithAllocation(PatientCreate):
     guardianId: int
+    doctorId: Optional[str] = None
+    gameTherapistId: Optional[str] = None
+    caregiverId: Optional[str] = None
     doctor2Id: Optional[str] = None
     supervisor2Id: Optional[str] = None

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -29,7 +29,7 @@ def get_active_staff_by_role(role: str, api_key: Optional[str]) -> list[str]:
             headers={"X-Api-Key": api_key},
             timeout=10.0,
         )
-    except httpx.ConnectError:
+    except httpx.HTTPError:
         raise HTTPException(status_code=503, detail="User service is unreachable.")
 
     if response.status_code == 403:
@@ -44,7 +44,7 @@ def get_active_staff_by_role(role: str, api_key: Optional[str]) -> list[str]:
     except (ValueError, AttributeError):
         raise HTTPException(status_code=503, detail="User service returned a malformed response.")
 
-    filtered = [u["id"] for u in users if u.get("role") == role]
+    filtered = [u.get("id") for u in users if u.get("role") == role and u.get("id")]
 
     if not filtered:
         raise HTTPException(
@@ -77,8 +77,8 @@ def get_least_loaded_staff(role: str, db: Session, api_key: Optional[str]) -> st
 
     def _sort_key(sid):
         try:
-            return (counts[sid], int(sid))
+            return (counts[sid], 0, int(sid), "")
         except (ValueError, TypeError):
-            return (counts[sid], sid)
+            return (counts[sid], 1, 0, str(sid))
 
     return min(counts, key=_sort_key)

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -1,0 +1,84 @@
+import os
+from typing import Optional
+
+import httpx
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from ..models.patient_allocation_model import PatientAllocation
+
+ROLE_COLUMN_MAP = {
+    "DOCTOR": "doctorId",
+    "GAME THERAPIST": "gameTherapistId",
+    "CAREGIVER": "caregiverId",
+    "SUPERVISOR": "supervisorId",
+}
+
+
+def get_active_staff_by_role(role: str, api_key: Optional[str]) -> list[str]:
+    if not api_key:
+        raise HTTPException(status_code=500, detail="INTERNAL_SERVICE_API_KEY is not configured.")
+
+    user_service_url = os.environ.get("USER_SERVICE_URL", "")
+    if not user_service_url:
+        raise HTTPException(status_code=500, detail="USER_SERVICE_URL is not configured.")
+
+    try:
+        response = httpx.get(
+            f"{user_service_url}/supervisor/get_active_staff",
+            headers={"X-Api-Key": api_key},
+            timeout=10.0,
+        )
+    except httpx.ConnectError:
+        raise HTTPException(status_code=503, detail="User service is unreachable.")
+
+    if response.status_code == 403:
+        raise HTTPException(status_code=403, detail="Invalid service API key for user service.")
+    if response.status_code != 200:
+        raise HTTPException(status_code=503, detail="User service returned an unexpected response.")
+
+    try:
+        users = response.json().get("users", None)
+        if users is None:
+            raise ValueError
+    except (ValueError, AttributeError):
+        raise HTTPException(status_code=503, detail="User service returned a malformed response.")
+
+    filtered = [u["id"] for u in users if u.get("role") == role]
+
+    if not filtered:
+        raise HTTPException(
+            status_code=503,
+            detail=f"No active staff found for role '{role}' in user service."
+        )
+
+    return filtered
+
+
+def get_least_loaded_staff(role: str, db: Session, api_key: Optional[str]) -> str:
+    staff_ids = get_active_staff_by_role(role, api_key)
+
+    column_name = ROLE_COLUMN_MAP.get(role)
+    if not column_name:
+        raise HTTPException(status_code=500, detail=f"Unknown role for allocation mapping: {role}")
+
+    column = getattr(PatientAllocation, column_name)
+
+    counts = {}
+    for staff_id in staff_ids:
+        count = (
+            db.query(PatientAllocation)
+            .filter(column == staff_id)
+            .filter(PatientAllocation.isDeleted == "0")
+            .filter(PatientAllocation.active == "Y")
+            .count()
+        )
+        counts[staff_id] = count
+
+    def _sort_key(sid):
+        try:
+            return (counts[sid], int(sid))
+        except (ValueError, TypeError):
+            return (counts[sid], sid)
+
+    return min(counts, key=_sort_key)

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -11,3 +11,4 @@ data:
   DB_DATABASE_PORT: "1433"
   RABBITMQ_HOST: "192.168.188.184"
   RABBITMQ_PORT: "5672"
+  USER_SERVICE_URL: "http://user-service.default.svc.cluster.local:8000"

--- a/sql/16_patient_allocation_carestaff_03_07_2026/01_add_columns.sql
+++ b/sql/16_patient_allocation_carestaff_03_07_2026/01_add_columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE [dbo].[PATIENT_ALLOCATION]
+    ADD doctor2Id NVARCHAR(255) NULL,
+        supervisor2Id NVARCHAR(255) NULL;

--- a/tests/unit/test_patient_crud_create_with_allocation.py
+++ b/tests/unit/test_patient_crud_create_with_allocation.py
@@ -1,0 +1,227 @@
+from datetime import datetime
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.schemas.patient import PatientCreateWithAllocation
+from tests.utils.mock_db import get_db_session_mock
+
+
+@pytest.fixture
+def db():
+    return get_db_session_mock()
+
+
+@pytest.fixture
+def patient_data():
+    return PatientCreateWithAllocation(
+        name="Test Patient",
+        nric="S1234567A",
+        gender="M",
+        dateOfBirth=datetime(1950, 1, 1),
+        isApproved="1",
+        updateBit="1",
+        autoGame="1",
+        startDate=datetime(2026, 1, 1),
+        isActive="1",
+        isRespiteCare="0",
+        privacyLevel=1,
+        createdDate=datetime.now(),
+        modifiedDate=datetime.now(),
+        CreatedById="1",
+        ModifiedById="1",
+        guardianId=1,
+    )
+
+
+def _setup_nric_clean(db):
+    """NRIC checks pass (no conflicts)."""
+    db.query.return_value.filter.return_value.first.return_value = None
+
+
+@patch("app.crud.patient_crud.log_crud_action")
+@patch("app.crud.patient_crud.get_outbox_service")
+@patch("app.crud.patient_crud.get_least_loaded_staff")
+def test_happy_path_auto_assign(mock_least, mock_outbox, mock_log, db, patient_data):
+    mock_least.side_effect = lambda role, db_, api_key: {
+        "DOCTOR": "D001", "GAME THERAPIST": "GT001", "CAREGIVER": "CG001"
+    }[role]
+
+    _setup_nric_clean(db)
+
+    guardian_mock = MagicMock()
+    new_patient_mock = MagicMock(id=42, nric="S1234567A")
+    db.query.return_value.filter.return_value.first.side_effect = [
+        None,           # NRIC check (patient)
+        None,           # NRIC check (guardian conflict)
+        guardian_mock,  # guardianId exists check
+        new_patient_mock,  # get new_patient after insert
+    ]
+
+    mock_outbox.return_value.create_event.return_value = MagicMock(id=99)
+
+    from app.crud.patient_crud import create_patient
+    result = create_patient(
+        db, patient_data, user="SUP1", user_full_name="Supervisor",
+        api_key="key", supervisor_id="SUP1"
+    )
+
+    db.commit.assert_called_once()
+    db.add.assert_called()
+
+
+@patch("app.crud.patient_crud.log_crud_action")
+@patch("app.crud.patient_crud.get_outbox_service")
+@patch("app.crud.patient_crud.get_least_loaded_staff")
+def test_explicit_ids_skip_user_service(mock_least, mock_outbox, mock_log, db, patient_data):
+    patient_data.doctorId = "D_EXPLICIT"
+    patient_data.gameTherapistId = "GT_EXPLICIT"
+    patient_data.caregiverId = "CG_EXPLICIT"
+
+    guardian_mock = MagicMock()
+    new_patient_mock = MagicMock(id=42, nric="S1234567A")
+    db.query.return_value.filter.return_value.first.side_effect = [
+        None, None, guardian_mock, new_patient_mock
+    ]
+    mock_outbox.return_value.create_event.return_value = MagicMock(id=99)
+
+    from app.crud.patient_crud import create_patient
+    create_patient(
+        db, patient_data, user="SUP1", user_full_name="Supervisor",
+        api_key="key", supervisor_id="SUP1"
+    )
+
+    mock_least.assert_not_called()
+
+
+@patch("app.crud.patient_crud.log_crud_action")
+@patch("app.crud.patient_crud.get_outbox_service")
+@patch("app.crud.patient_crud.get_least_loaded_staff")
+def test_partial_explicit_ids(mock_least, mock_outbox, mock_log, db, patient_data):
+    patient_data.doctorId = "D_EXPLICIT"
+
+    mock_least.side_effect = lambda role, db_, api_key: {
+        "GAME THERAPIST": "GT001", "CAREGIVER": "CG001"
+    }[role]
+
+    guardian_mock = MagicMock()
+    new_patient_mock = MagicMock(id=42, nric="S1234567A")
+    db.query.return_value.filter.return_value.first.side_effect = [
+        None, None, guardian_mock, new_patient_mock
+    ]
+    mock_outbox.return_value.create_event.return_value = MagicMock(id=99)
+
+    from app.crud.patient_crud import create_patient
+    create_patient(
+        db, patient_data, user="SUP1", user_full_name="Supervisor",
+        api_key="key", supervisor_id="SUP1"
+    )
+
+    called_roles = [c.args[0] for c in mock_least.call_args_list]
+    assert "DOCTOR" not in called_roles
+    assert "GAME THERAPIST" in called_roles
+    assert "CAREGIVER" in called_roles
+
+
+def test_doctor2_same_as_doctor(db, patient_data):
+    patient_data.doctorId = "D001"
+    patient_data.doctor2Id = "D001"
+
+    guardian_mock = MagicMock()
+    db.query.return_value.filter.return_value.first.side_effect = [
+        None,           # NRIC check (patient)
+        None,           # NRIC check (guardian conflict)
+        guardian_mock,  # guardianId exists
+    ]
+
+    from app.crud.patient_crud import create_patient
+    with pytest.raises(HTTPException) as exc:
+        create_patient(
+            db, patient_data, user="SUP1", user_full_name="Supervisor",
+            api_key="key", supervisor_id="SUP1"
+        )
+    assert exc.value.status_code == 400
+
+
+def test_supervisor2_same_as_supervisor(db, patient_data):
+    patient_data.supervisor2Id = "SUP1"
+
+    guardian_mock = MagicMock()
+    db.query.return_value.filter.return_value.first.side_effect = [
+        None,           # NRIC check (patient)
+        None,           # NRIC check (guardian conflict)
+        guardian_mock,  # guardianId exists
+    ]
+
+    from app.crud.patient_crud import create_patient
+    with pytest.raises(HTTPException) as exc:
+        create_patient(
+            db, patient_data, user="SUP1", user_full_name="Supervisor",
+            api_key="key", supervisor_id="SUP1"
+        )
+    assert exc.value.status_code == 400
+
+
+def test_guardian_not_found(db, patient_data):
+    db.query.return_value.filter.return_value.first.side_effect = [
+        None,   # NRIC check (patient)
+        None,   # NRIC check (guardian conflict)
+        None,   # guardianId check -> not found
+    ]
+
+    from app.crud.patient_crud import create_patient
+    with pytest.raises(HTTPException) as exc:
+        create_patient(
+            db, patient_data, user="SUP1", user_full_name="Supervisor",
+            api_key="key", supervisor_id="SUP1"
+        )
+    assert exc.value.status_code == 400
+
+
+@patch("app.crud.patient_crud.log_crud_action")
+@patch("app.crud.patient_crud.get_outbox_service")
+@patch("app.crud.patient_crud.get_least_loaded_staff")
+def test_user_service_unreachable_raises_503(mock_least, mock_outbox, mock_log, db, patient_data):
+    mock_least.side_effect = HTTPException(status_code=503, detail="unreachable")
+
+    guardian_mock = MagicMock()
+    new_patient_mock = MagicMock(id=42, nric="S1234567A")
+    db.query.return_value.filter.return_value.first.side_effect = [
+        None, None, guardian_mock, new_patient_mock
+    ]
+
+    from app.crud.patient_crud import create_patient
+    with pytest.raises(HTTPException) as exc:
+        create_patient(
+            db, patient_data, user="SUP1", user_full_name="Supervisor",
+            api_key="key", supervisor_id="SUP1"
+        )
+    assert exc.value.status_code == 503
+    db.rollback.assert_called()
+
+
+@patch("app.crud.patient_crud.log_crud_action")
+@patch("app.crud.patient_crud.get_outbox_service")
+@patch("app.crud.patient_crud.get_least_loaded_staff")
+def test_allocation_insert_fail_rolls_back(mock_least, mock_outbox, mock_log, db, patient_data):
+    mock_least.side_effect = lambda role, db_, api_key: "X001"
+
+    guardian_mock = MagicMock()
+    new_patient_mock = MagicMock(id=42, nric="S1234567A")
+    db.query.return_value.filter.return_value.first.side_effect = [
+        None, None, guardian_mock, new_patient_mock
+    ]
+    mock_outbox.return_value.create_event.return_value = MagicMock(id=99)
+
+    # First flush (patient) succeeds, second flush (allocation) fails
+    db.flush.side_effect = [None, SQLAlchemyError("allocation insert failed")]
+
+    from app.crud.patient_crud import create_patient
+    with pytest.raises((SQLAlchemyError, HTTPException)):
+        create_patient(
+            db, patient_data, user="SUP1", user_full_name="Supervisor",
+            api_key="key", supervisor_id="SUP1"
+        )
+    db.rollback.assert_called()

--- a/tests/unit/test_patient_crud_create_with_allocation.py
+++ b/tests/unit/test_patient_crud_create_with_allocation.py
@@ -225,3 +225,29 @@ def test_allocation_insert_fail_rolls_back(mock_least, mock_outbox, mock_log, db
             api_key="key", supervisor_id="SUP1"
         )
     db.rollback.assert_called()
+
+
+@patch("app.crud.patient_crud.log_crud_action")
+@patch("app.crud.patient_crud.get_outbox_service")
+@patch("app.crud.patient_crud.get_least_loaded_staff")
+def test_doctor2_same_as_auto_assigned_doctor(mock_least, mock_outbox, mock_log, db, patient_data):
+    patient_data.doctor2Id = "D001"
+    mock_least.side_effect = lambda role, db_, api_key: {
+        "DOCTOR": "D001", "GAME THERAPIST": "GT001", "CAREGIVER": "CG001"
+    }[role]
+
+    guardian_mock = MagicMock()
+    new_patient_mock = MagicMock(id=42, nric="S1234567A")
+    db.query.return_value.filter.return_value.first.side_effect = [
+        None, None, guardian_mock, new_patient_mock
+    ]
+    mock_outbox.return_value.create_event.return_value = MagicMock(id=99)
+
+    from app.crud.patient_crud import create_patient
+    with pytest.raises(HTTPException) as exc:
+        create_patient(
+            db, patient_data, user="SUP1", user_full_name="Supervisor",
+            api_key="key", supervisor_id="SUP1"
+        )
+    assert exc.value.status_code == 400
+    db.rollback.assert_called()

--- a/tests/unit/test_user_service.py
+++ b/tests/unit/test_user_service.py
@@ -1,0 +1,147 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from tests.utils.mock_db import get_db_session_mock
+
+
+@pytest.fixture
+def db_session_mock():
+    return get_db_session_mock()
+
+
+@pytest.fixture
+def api_key():
+    return "test-service-key"
+
+
+# --- get_active_staff_by_role tests ---
+
+def test_get_active_staff_by_role_missing_key():
+    from app.services.user_service import get_active_staff_by_role
+    with pytest.raises(HTTPException) as exc:
+        get_active_staff_by_role("DOCTOR", api_key=None)
+    assert exc.value.status_code == 500
+
+
+def test_get_active_staff_by_role_returns_filtered_list(api_key):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "users": [
+            {"id": "U001", "role": "DOCTOR"},
+            {"id": "U002", "role": "CAREGIVER"},
+            {"id": "U003", "role": "DOCTOR"},
+        ]
+    }
+    with patch("httpx.get", return_value=mock_response), \
+         patch.dict(os.environ, {"USER_SERVICE_URL": "http://user-service"}):
+        from app.services import user_service
+        import importlib; importlib.reload(user_service)
+        result = user_service.get_active_staff_by_role("DOCTOR", api_key=api_key)
+    assert result == ["U001", "U003"]
+
+
+def test_get_active_staff_by_role_wrong_key(api_key):
+    mock_response = MagicMock()
+    mock_response.status_code = 403
+    with patch("httpx.get", return_value=mock_response), \
+         patch.dict(os.environ, {"USER_SERVICE_URL": "http://user-service"}):
+        from app.services import user_service
+        import importlib; importlib.reload(user_service)
+        with pytest.raises(HTTPException) as exc:
+            user_service.get_active_staff_by_role("DOCTOR", api_key=api_key)
+        assert exc.value.status_code == 403
+
+
+def test_get_active_staff_by_role_unreachable(api_key):
+    import httpx
+    with patch("httpx.get", side_effect=httpx.ConnectError("unreachable")), \
+         patch.dict(os.environ, {"USER_SERVICE_URL": "http://user-service"}):
+        from app.services import user_service
+        import importlib; importlib.reload(user_service)
+        with pytest.raises(HTTPException) as exc:
+            user_service.get_active_staff_by_role("DOCTOR", api_key=api_key)
+        assert exc.value.status_code == 503
+
+
+def test_get_active_staff_by_role_empty_list(api_key):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"users": []}
+    with patch("httpx.get", return_value=mock_response), \
+         patch.dict(os.environ, {"USER_SERVICE_URL": "http://user-service"}):
+        from app.services import user_service
+        import importlib; importlib.reload(user_service)
+        with pytest.raises(HTTPException) as exc:
+            user_service.get_active_staff_by_role("DOCTOR", api_key=api_key)
+        assert exc.value.status_code == 503
+
+
+def test_get_active_staff_by_role_malformed_response(api_key):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"unexpected": "format"}
+    with patch("httpx.get", return_value=mock_response), \
+         patch.dict(os.environ, {"USER_SERVICE_URL": "http://user-service"}):
+        from app.services import user_service
+        import importlib; importlib.reload(user_service)
+        with pytest.raises(HTTPException) as exc:
+            user_service.get_active_staff_by_role("DOCTOR", api_key=api_key)
+        assert exc.value.status_code == 503
+
+
+# --- get_least_loaded_staff tests ---
+
+def test_get_least_loaded_staff_returns_least_loaded(db_session_mock, api_key):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "users": [
+            {"id": "U001", "role": "DOCTOR"},
+            {"id": "U002", "role": "DOCTOR"},
+        ]
+    }
+
+    call_count = {"n": 0}
+
+    def varying_count(*args, **kwargs):
+        mock_q = MagicMock()
+        call_count["n"] += 1
+        count = 3 if call_count["n"] == 1 else 1
+        mock_q.filter.return_value.filter.return_value.filter.return_value.count.return_value = count
+        return mock_q
+
+    db_session_mock.query.side_effect = varying_count
+
+    with patch("httpx.get", return_value=mock_response), \
+         patch.dict(os.environ, {"USER_SERVICE_URL": "http://user-service"}):
+        from app.services import user_service
+        import importlib; importlib.reload(user_service)
+        result = user_service.get_least_loaded_staff("DOCTOR", db_session_mock, api_key=api_key)
+
+    assert result == "U002"
+
+
+def test_get_least_loaded_staff_tiebreak_lowest_id(db_session_mock, api_key):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "users": [
+            {"id": "10", "role": "DOCTOR"},
+            {"id": "2", "role": "DOCTOR"},
+        ]
+    }
+    mock_q = MagicMock()
+    mock_q.filter.return_value.filter.return_value.filter.return_value.count.return_value = 0
+    db_session_mock.query.return_value = mock_q
+
+    with patch("httpx.get", return_value=mock_response), \
+         patch.dict(os.environ, {"USER_SERVICE_URL": "http://user-service"}):
+        from app.services import user_service
+        import importlib; importlib.reload(user_service)
+        result = user_service.get_least_loaded_staff("DOCTOR", db_session_mock, api_key=api_key)
+
+    assert result == "2"  # int("2") < int("10")

--- a/tests/unit/test_user_service.py
+++ b/tests/unit/test_user_service.py
@@ -145,3 +145,53 @@ def test_get_least_loaded_staff_tiebreak_lowest_id(db_session_mock, api_key):
         result = user_service.get_least_loaded_staff("DOCTOR", db_session_mock, api_key=api_key)
 
     assert result == "2"  # int("2") < int("10")
+
+
+def test_get_active_staff_by_role_timeout(api_key):
+    import httpx
+    with patch("httpx.get", side_effect=httpx.TimeoutException("timed out")), \
+         patch.dict(os.environ, {"USER_SERVICE_URL": "http://user-service"}):
+        from app.services import user_service
+        import importlib; importlib.reload(user_service)
+        with pytest.raises(HTTPException) as exc:
+            user_service.get_active_staff_by_role("DOCTOR", api_key=api_key)
+        assert exc.value.status_code == 503
+
+
+def test_get_active_staff_by_role_skips_entries_missing_id(api_key):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "users": [
+            {"role": "DOCTOR"},
+            {"id": "U003", "role": "DOCTOR"},
+        ]
+    }
+    with patch("httpx.get", return_value=mock_response), \
+         patch.dict(os.environ, {"USER_SERVICE_URL": "http://user-service"}):
+        from app.services import user_service
+        import importlib; importlib.reload(user_service)
+        result = user_service.get_active_staff_by_role("DOCTOR", api_key=api_key)
+    assert result == ["U003"]
+
+
+def test_get_least_loaded_staff_mixed_id_formats(db_session_mock, api_key):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "users": [
+            {"id": "abc-uuid", "role": "DOCTOR"},
+            {"id": "2", "role": "DOCTOR"},
+        ]
+    }
+    mock_q = MagicMock()
+    mock_q.filter.return_value.filter.return_value.filter.return_value.count.return_value = 0
+    db_session_mock.query.return_value = mock_q
+
+    with patch("httpx.get", return_value=mock_response), \
+         patch.dict(os.environ, {"USER_SERVICE_URL": "http://user-service"}):
+        from app.services import user_service
+        import importlib; importlib.reload(user_service)
+        result = user_service.get_least_loaded_staff("DOCTOR", db_session_mock, api_key=api_key)
+
+    assert result == "2"  # numeric IDs win over non-numeric on tie


### PR DESCRIPTION
## Summary

- `POST /patients/add` now atomically creates a `PATIENT_ALLOCATION` record in the same DB transaction — no patient can exist without allocated care staff
- Care staff (`doctorId`, `gameTherapistId`, `caregiverId`) are auto-assigned via least-loaded logic from user service if not explicitly provided; tie-break by lowest numeric ID
- `supervisorId` is set from the JWT `user_id` of the creating supervisor
- `guardianId` is required at creation; `doctor2Id` and `supervisor2Id` are optional
- Endpoint restricted to `SUPERVISOR` role (403 otherwise)
- Hard fail 503 if user service is unreachable during auto-assign

## Changes

- `sql/16_patient_allocation_carestaff_03_07_2026/01_add_columns.sql` — migration adding `doctor2Id`, `supervisor2Id` columns (already run on `fyp_dev_yeowkeng`)
- `app/models/patient_allocation_model.py` — added `doctor2Id`, `supervisor2Id` fields
- `app/schemas/patient.py` — added `PatientCreateWithAllocation` schema
- `app/services/user_service.py` — new HTTP client for user service auto-assign
- `app/crud/patient_crud.py` — extended `create_patient` with atomic allocation creation
- `app/routers/patient_router.py` — SUPERVISOR role enforcement, passes `api_key` + `supervisor_id`
- `k8s/configmap.yaml` — added `USER_SERVICE_URL`

## Post-review hardening (a7d8660)

- All httpx transport errors (incl. timeouts) now return 503 instead of leaking as 500
- Staff entries missing `id` in user service response are skipped instead of raising KeyError
- Stable least-loaded tie-break when staff IDs mix numeric and non-numeric formats
- `doctor2Id` colliding with an auto-assigned `doctorId` now rejected with 400

## Known gap

`INTERNAL_SERVICE_API_KEY` not yet added to k8s secret — pending handoff from user service team. Auto-assign will return 500 until key is configured.

## Out of scope (pre-existing, separate PR)

- Patient refetch by NRIC after insert lacks `isDeleted` filter — can attach records to a soft-deleted patient sharing the NRIC
- NRIC uniqueness is app-level only — concurrent creates can race; needs a filtered unique index at DB level