### PR TITLE
feat: complete user-service integration for auto-allocation

### DIFF
--- a/.github/workflows/base-cd.yaml
+++ b/.github/workflows/base-cd.yaml
@@ -59,6 +59,10 @@ on:
         required: true
       RABBITMQ_VIRTUAL_HOST:
         required: true
+      USER_SERVICE_URL:
+        required: true
+      INTERNAL_SERVICE_API_KEY:
+        required: true
 
 jobs:
   deploy:
@@ -106,6 +110,10 @@ jobs:
           echo "RABBITMQ_USER=${{ secrets.RABBITMQ_USER }}" >> .env
           echo "RABBITMQ_PASS=${{ secrets.RABBITMQ_PASS }}" >> .env
           echo "RABBITMQ_VIRTUAL_HOST=${{ secrets.RABBITMQ_VIRTUAL_HOST }}" >> .env
+
+          # User service (staff auto-assign + NRIC check)
+          echo "USER_SERVICE_URL=${{ secrets.USER_SERVICE_URL }}" >> .env
+          echo "INTERNAL_SERVICE_API_KEY=${{ secrets.INTERNAL_SERVICE_API_KEY }}" >> .env
 
       - name: Create Kubernetes Secret
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,6 +35,8 @@ jobs:
       RABBITMQ_USER: ${{ secrets.RABBITMQ_USER }}
       RABBITMQ_PASS: ${{ secrets.RABBITMQ_PASS }}
       RABBITMQ_VIRTUAL_HOST: ${{ secrets.RABBITMQ_VIRTUAL_HOST }}
+      USER_SERVICE_URL: ${{ secrets.USER_SERVICE_URL }}
+      INTERNAL_SERVICE_API_KEY: ${{ secrets.INTERNAL_SERVICE_API_KEY }}
 
   deploy-prod:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -25,7 +25,7 @@ def get_active_staff_by_role(role: str, api_key: Optional[str]) -> list[str]:
 
     try:
         response = httpx.get(
-            f"{user_service_url}/supervisor/get_active_staff",
+            f"{user_service_url}/api/v1/supervisor/get_active_staff",
             headers={"X-Api-Key": api_key},
             timeout=10.0,
         )


### PR DESCRIPTION
## Summary

Stacked on #222. Completes the user-service integration for the least-loaded
care-staff auto-assignment feature.

- `app/services/user_service.py`: aligned `get_active_staff_by_role`'s request
  path with PEAR_user_service's `/api/v1` route prefix
- `.github/workflows/base-cd.yaml` / `cd.yml` (deploy-staging): pass
  `USER_SERVICE_URL` and `INTERNAL_SERVICE_API_KEY` through the CD pipeline
  into the deployed container's environment
- deploy-prod intentionally left as-is until the same two secrets are added
  to the prod GitHub environment

## Verification

Full end-to-end test against the staging DB (see comment on #222):
`create_patient` with `guardianId` provided and `doctorId`/`caregiverId`
unset correctly auto-assigns from the real user-service candidate pool,
tie-broken as coded, and writes a correct atomic `PatientAllocation` row.

`USER_SERVICE_URL`/`INTERNAL_SERVICE_API_KEY` already added to the staging
GitHub environment secrets.